### PR TITLE
remove extra prefix from default name of app

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "azuread_application" "main" {
   name = (
     var.name != "" ?
     var.name :
-    "terraform-${random_id.name[0].hex}"
+    random_id.name[0].hex
   )
   available_to_other_tenants = false
 }


### PR DESCRIPTION
the default name of the app should be `terraform-<random-id>` and not `terraform-terraform-<random-id>`