### PR TITLE
Add role_id to allow for creating custom roles and passing it in

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,8 +46,8 @@ resource "azuread_service_principal_password" "main" {
 }
 
 resource "azurerm_role_assignment" "main" {
-  count              = var.role != "" ? length(local.scopes) : 0
+  count              = var.role_id != "" || var.role != "" ? length(local.scopes) : 0
   scope              = local.scopes[count.index]
-  role_definition_id = format("%s%s", data.azurerm_subscription.main.id, data.azurerm_role_definition.main[0].id)
+  role_definition_id = var.role_id == "" ? format("%s%s", data.azurerm_subscription.main.id, data.azurerm_role_definition.main[0].id) : var.role_id
   principal_id       = azuread_service_principal.main.id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,12 @@ variable "role" {
   description = "The name of a role for the service principal."
 }
 
+variable "role_id" {
+  type        = string
+  default     = ""
+  description = "The id of a role for the service principal. (use role or role_id)"
+}
+
 variable "scopes" {
   type        = list(string)
   default     = []


### PR DESCRIPTION
I had a terraform where I created a azurerm_role_definition and wanted to pass it into your module. 
I ran into two issues at first
1. either the data azurerm_role_definition would fail saying the role didn't exist yet. or 
1. the terraform error where the current state can't be determined till after an apply, use targets to resolve.

Here is how I'm using it now with this change
```hcl
# Create a role that has only the permissions condor needs
resource azurerm_role_definition bob {
  name  = "bob-role-definition"
  scope = var.resource_group_id

  permissions {
    actions = [
      "Microsoft.Network/virtualNetworks/read",
      "Microsoft.Network/virtualNetworks/subnets/read",
      "Microsoft.Network/networkInterfaces/*",
      "Microsoft.Compute/virtualMachines/read",
      "Microsoft.Compute/*",
    ]
    data_actions     = []
    not_actions      = []
    not_data_actions = []
  }

  assignable_scopes = [
    var.resource_group_id
  ]
}


# Create a service principal
# https://github.com/innovationnorway/terraform-azuread-service-principal
module service_principal_condor {
  # source  = "innovationnorway/service-principal/azuread"
  #version = "3.0.0-alpha.1"
  source  = "./terraform-azuread-service-principal-master"
  name    = "bob"
  years   = 2
  role_id = azurerm_role_definition.condor.id
  scopes  = [var.resource_group_id]
  depends = [azurerm_role_definition.condor]
}
```