### PR TITLE
Various fixes and upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ override.tf.json
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 tfplan
 *.tfplan
+.idea

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ data "azurerm_role_definition" "main" {
 data "azurerm_subscription" "main" {}
 
 resource "azuread_application" "main" {
-  name = var.name
+  display_name = var.name
   identifier_uris = [
     format("http://%s", var.name)
   ]

--- a/test/main.tf
+++ b/test/main.tf
@@ -17,7 +17,7 @@ module "service_principal" {
 }
 
 data "azuread_application" "test" {
-  name = module.service_principal.name
+  display_name = module.service_principal.name
 }
 
 output "service_principal" {

--- a/versions.tf
+++ b/versions.tf
@@ -2,19 +2,19 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     azuread = {
-      source = "hashicorp/azuread"
+      source  = "hashicorp/azuread"
       version = ">= 1.2.2"
     }
     azurerm = {
-      source = "hashicorp/azurerm"
+      source  = "hashicorp/azurerm"
       version = ">= 2.4.0"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
       version = ">= 2.2.0"
     }
     time = {
-      source = "hashicorp/time"
+      source  = "hashicorp/time"
       version = ">= 0.4.0"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,21 @@
 terraform {
-  required_version = ">= 0.12.21"
+  required_version = ">= 0.13.0"
   required_providers {
-    azuread = ">= 0.8.0"
-    azurerm = ">= 2.4.0"
-    random  = ">= 2.2.0"
-    time    = ">= 0.4.0"
+    azuread = {
+      source = "hashicorp/azuread"
+      version = ">= 1.2.2"
+    }
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = ">= 2.4.0"
+    }
+    random = {
+      source = "hashicorp/random"
+      version = ">= 2.2.0"
+    }
+    time = {
+      source = "hashicorp/time"
+      version = ">= 0.4.0"
+    }
   }
 }


### PR DESCRIPTION
* ignore IntelliJ idea files so that you can use IntelliJ without much hassle
* finish upgrade for Terraform 0.13 compatiblity
* fix deprecated `name` property (replaced by `display_name`) In Terraform Azure AD provider